### PR TITLE
#9: Tag container images with commit SHA

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -38,13 +38,13 @@ jobs:
 
       - name: Tag images
         run: |
-          docker tag petpal/demo-api undeadoutlook/petpal-demo-api:latest
-          docker tag petpal/demo-nginx undeadoutlook/petpal-demo-nginx:latest
+          docker tag petpal/demo-api undeadoutlook/petpal-demo-api:${{ github.run_id }}
+          docker tag petpal/demo-nginx undeadoutlook/petpal-demo-nginx:${{ github.run_id }}
 
       - name: Push to DockerHub
         run: |
-          docker push undeadoutlook/petpal-demo-api:latest
-          docker push undeadoutlook/petpal-demo-nginx:latest
+          docker push undeadoutlook/petpal-demo-api:${{ github.run_id }}
+          docker push undeadoutlook/petpal-demo-nginx:${{ github.run_id }}
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -38,13 +38,13 @@ jobs:
 
       - name: Tag images
         run: |
-          docker tag petpal/demo-api undeadoutlook/petpal-demo-api:${{ github.run_id }}
-          docker tag petpal/demo-nginx undeadoutlook/petpal-demo-nginx:${{ github.run_id }}
+          docker tag petpal/demo-api undeadoutlook/petpal-demo-api:${{ github.event.pull_request.head.sha }}
+          docker tag petpal/demo-nginx undeadoutlook/petpal-demo-nginx:${{ github.event.pull_request.head.sha }}
 
       - name: Push to DockerHub
         run: |
-          docker push undeadoutlook/petpal-demo-api:${{ github.run_id }}
-          docker push undeadoutlook/petpal-demo-nginx:${{ github.run_id }}
+          docker push undeadoutlook/petpal-demo-api:${{ github.event.pull_request.head.sha }}
+          docker push undeadoutlook/petpal-demo-nginx:${{ github.event.pull_request.head.sha }}
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves #9, both the nginx and django containers are being pushed to Dockerhub on every merge into `main`.