### PR TITLE
Change Deployment Strategy

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -40,22 +40,22 @@ jobs:
 
       - name: Build container images
         run: |
-          docker build -t petpal/demo-api ./api
-          docker build -t petpal/demo-nginx ./nginx
+          docker build -t django-api ./api
+          docker build -t django-nginx ./nginx
 
       - name: Tag images
         run: |
-          docker tag petpal/demo-api ${{ secrets.DOCKERHUB_USERNAME }}/petpal-demo-api:${{ github.sha }}
-          docker tag petpal/demo-api ${{ secrets.DOCKERHUB_USERNAME }}/petpal-demo-api:latest
-          docker tag petpal/demo-api ${{ secrets.DOCKERHUB_USERNAME }}/petpal-demo-api:0.1.0
-          docker tag petpal/demo-nginx ${{ secrets.DOCKERHUB_USERNAME }}/petpal-demo-nginx:${{ github.sha }}
-          docker tag petpal/demo-nginx ${{ secrets.DOCKERHUB_USERNAME }}/petpal-demo-nginx:latest
-          docker tag petpal/demo-nginx ${{ secrets.DOCKERHUB_USERNAME }}/petpal-demo-nginx:0.1.0
+          docker tag django-api ${{ secrets.DOCKERHUB_USERNAME }}/petpal-django-api:${{ github.sha }}
+          docker tag django-api ${{ secrets.DOCKERHUB_USERNAME }}/petpal-django-api:latest
+          docker tag django-api ${{ secrets.DOCKERHUB_USERNAME }}/petpal-django-api:0.1.0
+          docker tag django-nginx ${{ secrets.DOCKERHUB_USERNAME }}/petpal-django-nginx:${{ github.sha }}
+          docker tag django-nginx ${{ secrets.DOCKERHUB_USERNAME }}/petpal-django-nginx:latest
+          docker tag django-nginx ${{ secrets.DOCKERHUB_USERNAME }}/petpal-django-nginx:0.1.0
 
       - name: Push to DockerHub
         run: |
-          docker push --all-tags ${{ secrets.DOCKERHUB_USERNAME }}/petpal-demo-api
-          docker push --all-tags ${{ secrets.DOCKERHUB_USERNAME}}/petpal-demo-nginx
+          docker push --all-tags ${{ secrets.DOCKERHUB_USERNAME }}/petpal-django-api
+          docker push --all-tags ${{ secrets.DOCKERHUB_USERNAME}}/petpal-django-nginx
 
   deploy:
     name: Deploy to ECS

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -77,5 +77,11 @@ jobs:
       - name: Compress Source Code
         run: zip -r source.zip ./
 
+      - name: Archive Source Code
+        uses: actions/upload-artifact@v3
+        with:
+          name: Compressed Source (.zip)
+          path: ./source.zip
+
       - name: Push to S3
         run: aws s3 cp source.zip s3://django-api-source-code

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -58,7 +58,7 @@ jobs:
           docker push --all-tags ${{ secrets.DOCKERHUB_USERNAME}}/petpal-django-nginx
 
   deploy:
-    name: Deploy to ECS
+    name: Push to S3
     runs-on: ubuntu-latest
     needs:
       - build
@@ -74,21 +74,8 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - name: Update Docker compose
-        run: sudo curl -L https://raw.githubusercontent.com/docker/compose-cli/main/scripts/install/install_linux.sh | sudo sh
+      - name: Compress Source Code
+        run: zip -r source.zip ./
 
-      - name: Check Docker Versions
-        run: |
-          docker -v
-          docker compose version
-
-      - name: Create ECS Context
-        run: |
-          docker context create ecs petpal-ecs --from-env
-          docker context use petpal-ecs
-
-      - name: Test CloudFormation template
-        run: docker --debug compose convert
-
-      - name: Deploy Cluster Resources
-        run: docker compose up
+      - name: Push to S3
+        run: aws s3 cp source.zip s3://django-api-source-code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   nginx:
-    image: undeadoutlook/petpal-demo-nginx:0.1.0
+    image: undeadoutlook/petpal-django-nginx:0.1.0
     volumes:
       - static_assets:/app/staticfiles
     ports:
@@ -9,7 +9,7 @@ services:
       - api
     container_name: nginx
   api:
-    image: undeadoutlook/petpal-demo-api:0.1.0
+    image: undeadoutlook/petpal-django-api:0.1.0
     volumes:
       - static_assets:/app/staticfiles
     restart: on-failure


### PR DESCRIPTION
Trying to set up the docker compose ECS integration directly in GitHub actions has been difficult. Instead I'm going to try splitting up CI/CD responsibility between GitHub actions and AWS CodePipeline. 

GitHub actions will be responsible for running CI checks: build checks, tests and pushing the source code to S3. AWS will take grab the code from S3 and run automated deployment from there.